### PR TITLE
Fix narrow page width for read the docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,5 +81,8 @@ else:
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+def setup(app):
+   app.add_css_file("stylesheet.css")
+
 # to make crossreferencing section names between documents work
 autosectionlabel_prefix_document = True

--- a/docs/source/stylesheet.css
+++ b/docs/source/stylesheet.css
@@ -1,0 +1,3 @@
+.wy-nav-content {
+   max-width: none;
+}


### PR DESCRIPTION
Issue: I have scroll the page left and right several times to read the content of the tables
![image](https://user-images.githubusercontent.com/5083532/210152443-28685639-1903-47ce-b59d-283071e3ff41.png)


Ref: https://github.com/readthedocs/sphinx_rtd_theme/issues/295#issuecomment-455226058